### PR TITLE
using replaceAll in the Copier so that we can use regex for filters

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-io", version: "2.0.0-RC.6", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-io", version: "2.0.0-RC.7", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/org/savantbuild/io/Copier.java
+++ b/src/main/java/org/savantbuild/io/Copier.java
@@ -63,7 +63,7 @@ public class Copier {
           // into memory, filter them, then write it out
           String contents = new String(Files.readAllBytes(fileInfo.origin), "UTF-8");
           for (Filter filter : filters) {
-            contents = contents.replace(filter.token, filter.value);
+            contents = contents.replaceAll(filter.token, filter.value);
           }
           Files.write(target, contents.getBytes("UTF-8"));
         }

--- a/src/test/java/org/savantbuild/io/CopierTest.java
+++ b/src/test/java/org/savantbuild/io/CopierTest.java
@@ -56,6 +56,7 @@ public class CopierTest extends BaseUnitTest {
     copier.fileSet(new FileSet(BaseUnitTest.projectDir.resolve("src/test/java"), asList(Pattern.compile(".*/io/.*")), asList(Pattern.compile(".*FileSet.*"))))
           .filter("%TOKEN1%", "token1")
           .filter("%TOKEN4%", "token4")
+          .filter("\n.*\\@Token5\\(\\w*\\)\n", " and ")
           .copy();
 
     assertTrue(Files.isRegularFile(toDir.resolve("org/savantbuild/io/CopierTest.java")));
@@ -64,7 +65,8 @@ public class CopierTest extends BaseUnitTest {
 
     assertEquals(new String(Files.readAllBytes(toDir.resolve("org/savantbuild/io/TestFilterFile.txt"))),
         "This file contains token1 and %TOKEN2%\n" +
-            "It should be replaced with %TOKEN3% and token4");
+            "It should be replaced with %TOKEN3% and token4\n" +
+            "Also the next line and this line and this one should be one line");
   }
 
   @Test

--- a/src/test/java/org/savantbuild/io/TestFilterFile.txt
+++ b/src/test/java/org/savantbuild/io/TestFilterFile.txt
@@ -1,2 +1,7 @@
 This file contains %TOKEN1% and %TOKEN2%
 It should be replaced with %TOKEN3% and %TOKEN4%
+Also the next line
+@Token5(foo)
+this line
+@Token5(bar)
+this one should be one line


### PR DESCRIPTION
I don't think this breaks anything but gives the option to add a regex which can do things like remove annotations with arbitrary content inside, for example