### PR TITLE
Bump version to 2.1.0 for cache-performance

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-io", version: "2.0.0", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-io", version: "2.1.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()


### PR DESCRIPTION
## Summary
- Bump project version to 2.1.0 to align all core Savant projects for the cache-performance feature

## Test plan
- [ ] Verify `sb int` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)